### PR TITLE
Enable automatic Ballerina central push

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 org.gradle.caching=true
 group=org.ballerinalang
-version=0.6.4-SNAPSHOT
+version=0.6.5-SNAPSHOT
 ballerinaLangVersion=2.0.0-SNAPSHOT

--- a/socket-ballerina/build.gradle
+++ b/socket-ballerina/build.gradle
@@ -60,6 +60,7 @@ def artifactSocketBallerinaDocs = file("$project.projectDir/build/docs_parent/")
 def artifactSocketCacheParent = file("$project.projectDir/build/cache_parent/")
 def artifactSocketLibParent = file("$project.projectDir/build/lib_parent/")
 def tomlVersion = project.version.split("-")[0]
+def ballerinaCentralAccessToken = System.getenv('BALLERINA_CENTRAL_ACCESS_TOKEN')
 def targetSocketBallerinaJar = file("$project.projectDir/target/caches/jar_cache/ballerina/socket/${tomlVersion}/ballerina-socket-${tomlVersion}.jar")
 def targetSocketNativeJar = file("$project.rootDir/socket-native/build/libs/socket-native-${project.version}.jar")
 
@@ -118,6 +119,20 @@ task ballerinaBuild {
             into file("$artifactSocketLibParent/libs")
         }
 
+        // Publish to central
+        if (!project.version.endsWith('-SNAPSHOT') && ballerinaCentralAccessToken != null && project.hasProperty("publishToCentral")) {
+            println("Publishing to the ballerina central..")
+            exec {
+                workingDir project.projectDir
+                environment "JAVA_OPTS", "-DBALLERINA_DEV_COMPILE_BALLERINA_ORG=true"
+                if (Os.isFamily(Os.FAMILY_WINDOWS)) {
+                    commandLine 'cmd', '/c', "$distributionBinPath/ballerina.bat push socket"
+                } else {
+                    commandLine 'sh', '-c', "$distributionBinPath/ballerina push socket"
+                }
+            }
+
+        }
         // Doc creation and packing
         exec {
             workingDir project.projectDir

--- a/socket-native/src/main/java/org/ballerinalang/stdlib/socket/SocketConstants.java
+++ b/socket-native/src/main/java/org/ballerinalang/stdlib/socket/SocketConstants.java
@@ -32,7 +32,7 @@ public class SocketConstants {
     public static final String SERVER_SOCKET_KEY = "ServerSocket";
     public static final String SOCKET_KEY = "Socket";
     public static final String SOCKET_PACKAGE = "ballerina/socket";
-    public static final BPackage SOCKET_PACKAGE_ID = new BPackage(BALLERINA_BUILTIN_PKG_PREFIX, "socket", "0.6.4");
+    public static final BPackage SOCKET_PACKAGE_ID = new BPackage(BALLERINA_BUILTIN_PKG_PREFIX, "socket", "0.6.5");
     public static final String RESOURCE_ON_CONNECT = "onConnect";
     public static final String RESOURCE_ON_READ_READY = "onReadReady";
     public static final String RESOURCE_ON_ERROR = "onError";


### PR DESCRIPTION
## Purpose
Fixes https://github.com/ballerina-platform/module-ballerina-socket/issues/29

## Approach
Only publish to the ballerina central when the following 3 conditions are satisfied
1. Project version should not be a `-SNAPSHOT` version
1. Ballerina central access token should be configured as an env
1. `publishToCentral` property has to specified

## Test environment
- macOS
- Ballerina 2.0.0 Preview1-m6
