### PR TITLE
Enable isolation for socket APIs

### DIFF
--- a/socket-ballerina/src/socket/client_socket.bal
+++ b/socket-ballerina/src/socket/client_socket.bal
@@ -36,7 +36,7 @@ public client class Client {
     # Initializes the TCP socket client with the given client configuration.
     #
     # + clientConfig - This is used to provide the configurations like host, port, and timeout
-    public function init(ClientConfig? clientConfig) {
+    public isolated function init(ClientConfig? clientConfig) {
         if (clientConfig is ClientConfig) {
             self.config = clientConfig;
             var initResult = initClientEndpoint(self, clientConfig);
@@ -58,7 +58,7 @@ public client class Client {
     #
     # + content - The content, which will be sent to the client socket
     # + return - The number of bytes that got written or else a `socket:Error` if the given data can't be written
-    public remote function write(byte[] content) returns int|Error {
+    public isolated remote function write(byte[] content) returns int|Error {
         return externWrite(self, content);
     }
 
@@ -74,7 +74,7 @@ public client class Client {
     # + length - Represents the number of bytes, which should be read
     # + return - Content as a byte array and the number of bytes read or else a `socket:ReadTimedOutError` if the data
     #            can't be read from the client
-    public remote function read(int length = -100) returns @tainted [byte[], int]|ReadTimedOutError {
+    public isolated remote function read(int length = -100) returns @tainted [byte[], int]|ReadTimedOutError {
         return externRead(self, length);
     }
 
@@ -84,7 +84,7 @@ public client class Client {
     # ```
     #
     # + return - A `socket:Error` if the client can't close the connection or else `()`
-    public remote function close() returns Error? {
+    public isolated remote function close() returns Error? {
         return closeClient(self);
     }
 
@@ -94,7 +94,7 @@ public client class Client {
     # ```
     #
     # + return - A `socket:Error` if the client can't be shut down to stop reading from the socket or else `()`
-    public remote function shutdownRead() returns Error? {
+    public isolated remote function shutdownRead() returns Error? {
         return externShutdownRead(self);
     }
 
@@ -104,7 +104,7 @@ public client class Client {
     # ```
     #
     # + return - A `socket:Error` if the client can't shut down to stop the writing to the socket or else `()`
-    public remote function shutdownWrite() returns Error? {
+    public isolated remote function shutdownWrite() returns Error? {
         return externShutdownWrite(self);
     }
 }
@@ -124,43 +124,43 @@ public type ClientConfig record {|
     service callbackService?;
 |};
 
-function initClientEndpoint(Client clientObj, ClientConfig clientConfig) returns error? =
+isolated function initClientEndpoint(Client clientObj, ClientConfig clientConfig) returns error? =
 @java:Method {
     name: "initEndpoint",
     'class: "org.ballerinalang.stdlib.socket.endpoint.tcp.ClientActions"
 } external;
 
-function startClient(Client clientObj) returns error? =
+isolated function startClient(Client clientObj) returns error? =
 @java:Method {
     name: "start",
     'class: "org.ballerinalang.stdlib.socket.endpoint.tcp.ClientActions"
 } external;
 
-function externWrite(Client clientObj, byte[] content) returns int|Error =
+isolated function externWrite(Client clientObj, byte[] content) returns int|Error =
 @java:Method {
     name: "write",
     'class: "org.ballerinalang.stdlib.socket.endpoint.tcp.ClientActions"
 } external;
 
-function externRead(Client clientObj, int length) returns [byte[], int]|ReadTimedOutError =
+isolated function externRead(Client clientObj, int length) returns [byte[], int]|ReadTimedOutError =
 @java:Method {
     name: "read",
     'class: "org.ballerinalang.stdlib.socket.endpoint.tcp.ClientActions"
 } external;
 
-function closeClient(Client clientObj) returns Error? =
+isolated function closeClient(Client clientObj) returns Error? =
 @java:Method {
     name: "close",
     'class: "org.ballerinalang.stdlib.socket.endpoint.tcp.ClientActions"
 } external;
 
-function externShutdownRead(Client clientObj) returns Error? =
+isolated function externShutdownRead(Client clientObj) returns Error? =
 @java:Method {
     name: "shutdownRead",
     'class: "org.ballerinalang.stdlib.socket.endpoint.tcp.ClientActions"
 } external;
 
-function externShutdownWrite(Client clientObj) returns Error? =
+isolated function externShutdownWrite(Client clientObj) returns Error? =
 @java:Method {
     name: "shutdownWrite",
     'class: "org.ballerinalang.stdlib.socket.endpoint.tcp.ClientActions"

--- a/socket-ballerina/src/socket/listener_endpoint.bal
+++ b/socket-ballerina/src/socket/listener_endpoint.bal
@@ -26,7 +26,7 @@ public class Listener {
     #
     # + port - The port number of the remote service
     # + config - Configurations related to the `socket:Listener`
-    public function init(int port, ListenerConfig? config = ()) {
+    public isolated function init(int port, ListenerConfig? config = ()) {
         var result = initServer(self, port, config ?: {});
         if (result is error) {
             panic result;
@@ -39,7 +39,7 @@ public class Listener {
     # ```
     #
     # + return - `()` or else a `socket:Error` upon failure to start the listener
-    public function __start() returns error? {
+    public isolated function __start() returns error? {
         return startService(self);
     }
 
@@ -49,7 +49,7 @@ public class Listener {
     # ```
     #
     # + return - `()` or else a `socket:Error` upon failure to stop the listener
-    public function __gracefulStop() returns error? {
+    public isolated function __gracefulStop() returns error? {
         return externStop(self, true);
     }
 
@@ -59,7 +59,7 @@ public class Listener {
     # ```
     #
     # + return - `()` or else a `socket:Error` upon failure to stop the listener
-    public function __immediateStop() returns error? {
+    public isolated function __immediateStop() returns error? {
         return externStop(self, false);
     }
 
@@ -71,7 +71,7 @@ public class Listener {
     # + s - Type descriptor of the service
     # + name - Name of the service
     # + return - `()` or else a `socket:Error` upon failure to register the listener
-    public function __attach(service s, string? name = ()) returns error? {
+    public isolated function __attach(service s, string? name = ()) returns error? {
         return externRegister(self, s);
     }
 
@@ -82,7 +82,7 @@ public class Listener {
     #
     # + s - Type descriptor of the service
     # + return - `()` or else a `socket:Error` upon failure to detach the service
-    public function __detach(service s) returns error? {
+    public isolated function __detach(service s) returns error? {
     // Socket listener operations are strictly bound to the attached service. In fact, a listener doesn't support
     // multiple services. Therefore, an already attached service is not removed during the detachment.
     }
@@ -98,24 +98,24 @@ public type ListenerConfig record {|
     int readTimeoutInMillis = 300000;
 |};
 
-function initServer(Listener lis, int port, ListenerConfig config) returns error? =
+isolated function initServer(Listener lis, int port, ListenerConfig config) returns error? =
 @java:Method {
     'class: "org.ballerinalang.stdlib.socket.endpoint.tcp.ServerActions"
 } external;
 
-function externRegister(Listener lis, service s) returns error? =
+isolated function externRegister(Listener lis, service s) returns error? =
 @java:Method {
     name: "register",
     'class: "org.ballerinalang.stdlib.socket.endpoint.tcp.ServerActions"
 } external;
 
-function startService(Listener lis) returns error? =
+isolated function startService(Listener lis) returns error? =
 @java:Method {
     name: "start",
     'class: "org.ballerinalang.stdlib.socket.endpoint.tcp.ServerActions"
 } external;
 
-function externStop(Listener lis, boolean graceful) returns error? =
+isolated function externStop(Listener lis, boolean graceful) returns error? =
 @java:Method {
     name: "stop",
     'class: "org.ballerinalang.stdlib.socket.endpoint.tcp.ServerActions"

--- a/socket-ballerina/src/socket/udp_client_socket.bal
+++ b/socket-ballerina/src/socket/udp_client_socket.bal
@@ -33,7 +33,7 @@ public client class UdpClient {
     #
     # + localAddress - Local binding of the interface and port
     # + config - The configurations for the UDP client
-    public function init(Address? localAddress = (), UdpClientConfig? config = ()) {
+    public isolated function init(Address? localAddress = (), UdpClientConfig? config = ()) {
         UdpClientConfig configuration = config ?: {};
         self.localAddress = localAddress;
         var initResult = initUdpClientEndpoint(self, localAddress, configuration);
@@ -53,7 +53,7 @@ public client class UdpClient {
     # + content - The content to be sent to the client socket
     # + address - The address of the remote client socket
     # + return - The number of bytes got written or else a `socket:Error` if the given data can't be sent
-    public remote function sendTo(byte[] content, Address address) returns int|Error {
+    public isolated remote function sendTo(byte[] content, Address address) returns int|Error {
         return udpClientSendTo(self, content, address);
     }
 
@@ -67,7 +67,7 @@ public client class UdpClient {
     # + length - Represents the number of bytes, which should be read
     # + return - The content as a byte array, the number of bytes read, the address of the sender,
     #            or else a `socket:Error` if the data can't be read from the client
-    public remote function receiveFrom(int length = -100) returns [byte[], int, Address]|ReadTimedOutError {
+    public isolated remote function receiveFrom(int length = -100) returns [byte[], int, Address]|ReadTimedOutError {
         return externReceiveFrom(self, length);
     }
 
@@ -77,7 +77,7 @@ public client class UdpClient {
     # ```
     #
     # + return - A `socket:Error` if it can't close the connection or else `()`
-    public remote function close() returns Error? {
+    public isolated remote function close() returns Error? {
         return closeUdpClient(self);
     }
 }
@@ -99,25 +99,25 @@ public type UdpClientConfig record {|
     int readTimeoutInMillis = 300000;
 |};
 
-function initUdpClientEndpoint(UdpClient udpClient, Address? localAddress, UdpClientConfig config) returns error? =
+isolated function initUdpClientEndpoint(UdpClient udpClient, Address? localAddress, UdpClientConfig config) returns error? =
 @java:Method {
     name: "initEndpoint",
     'class: "org.ballerinalang.stdlib.socket.endpoint.udp.ClientActions"
 } external;
 
-function closeUdpClient(UdpClient udpClient) returns Error? =
+isolated function closeUdpClient(UdpClient udpClient) returns Error? =
 @java:Method {
     name: "close",
     'class: "org.ballerinalang.stdlib.socket.endpoint.udp.ClientActions"
 } external;
 
-function externReceiveFrom(UdpClient udpClient, int length) returns [byte[], int, Address]|ReadTimedOutError =
+isolated function externReceiveFrom(UdpClient udpClient, int length) returns [byte[], int, Address]|ReadTimedOutError =
 @java:Method {
     name: "receiveFrom",
     'class: "org.ballerinalang.stdlib.socket.endpoint.udp.ClientActions"
 } external;
 
-function udpClientSendTo(UdpClient udpClient, byte[] content, Address address) returns int|Error =
+isolated function udpClientSendTo(UdpClient udpClient, byte[] content, Address address) returns int|Error =
 @java:Method {
     name: "sendTo",
     'class: "org.ballerinalang.stdlib.socket.endpoint.udp.ClientActions"


### PR DESCRIPTION
## Purpose
Fixes https://github.com/ballerina-platform/module-ballerina-socket/issues/47

## Approach
Add `isolated` keyword

## Test environment
- Java 8
- macOS
- SLP4