### PR TITLE
Migrate NonBlockingCallback to BalEnv

### DIFF
--- a/socket-native/src/main/java/org/ballerinalang/stdlib/socket/tcp/ChannelRegisterCallback.java
+++ b/socket-native/src/main/java/org/ballerinalang/stdlib/socket/tcp/ChannelRegisterCallback.java
@@ -18,8 +18,8 @@
 
 package org.ballerinalang.stdlib.socket.tcp;
 
+import org.ballerinalang.jvm.api.BalFuture;
 import org.ballerinalang.jvm.api.values.BError;
-import org.ballerinalang.jvm.values.connector.NonBlockingCallback;
 
 /**
  * This will hold the {@link SocketService}.
@@ -29,12 +29,12 @@ import org.ballerinalang.jvm.values.connector.NonBlockingCallback;
 public class ChannelRegisterCallback {
 
     private SocketService socketService;
-    private NonBlockingCallback callback;
+    private BalFuture balFuture;
     private final int initialInterest;
 
-    public ChannelRegisterCallback(SocketService socketService, NonBlockingCallback callback, int initialInterest) {
+    public ChannelRegisterCallback(SocketService socketService, BalFuture balFuture, int initialInterest) {
         this.socketService = socketService;
-        this.callback = callback;
+        this.balFuture = balFuture;
         this.initialInterest = initialInterest;
     }
 
@@ -52,7 +52,7 @@ public class ChannelRegisterCallback {
      * @param serviceAttached whether to invoke onConnect or not.
      */
     public void notifyRegister(boolean serviceAttached) {
-        callback.notifySuccess();
+        balFuture.complete(null);
         if (serviceAttached) {
             SelectorDispatcher.invokeOnConnect(socketService);
         }
@@ -65,7 +65,7 @@ public class ChannelRegisterCallback {
      */
     public void notifyFailure(String errorMsg) {
         BError error = SocketUtils.createSocketError(errorMsg);
-        callback.notifyFailure(error);
+        balFuture.complete(error);
         // We don't need to dispatch the error to the onError here.
         // This should treated as a panic and stop listener/client getting start.
     }

--- a/socket-native/src/main/java/org/ballerinalang/stdlib/socket/tcp/ReadPendingCallback.java
+++ b/socket-native/src/main/java/org/ballerinalang/stdlib/socket/tcp/ReadPendingCallback.java
@@ -18,8 +18,8 @@
 
 package org.ballerinalang.stdlib.socket.tcp;
 
+import org.ballerinalang.jvm.api.BalFuture;
 import org.ballerinalang.jvm.api.values.BError;
-import org.ballerinalang.jvm.values.connector.NonBlockingCallback;
 import org.ballerinalang.stdlib.socket.SocketConstants;
 
 import java.nio.ByteBuffer;
@@ -33,7 +33,7 @@ import java.util.TimerTask;
  */
 public class ReadPendingCallback {
 
-    private NonBlockingCallback callback;
+    private BalFuture balFuture;
     private final int expectedLength;
     private int currentLength;
     private ByteBuffer buffer;
@@ -41,16 +41,16 @@ public class ReadPendingCallback {
     private Timer timer;
     private long timeout;
 
-    public ReadPendingCallback(NonBlockingCallback callback, int expectedLength, int socketHash, long timeout) {
-        this.callback = callback;
+    public ReadPendingCallback(BalFuture balFuture, int expectedLength, int socketHash, long timeout) {
+        this.balFuture = balFuture;
         this.expectedLength = expectedLength;
         this.socketHash = socketHash;
         this.timeout = timeout;
         scheduleTimeout(timeout);
     }
 
-    public NonBlockingCallback getCallback() {
-        return callback;
+    public BalFuture getFuture() {
+        return balFuture;
     }
 
     public int getExpectedLength() {
@@ -104,8 +104,7 @@ public class ReadPendingCallback {
                 ReadPendingSocketMap.getInstance().remove(socketHash);
                 final BError timeoutError =
                         SocketUtils.createSocketError(SocketConstants.ErrorType.ReadTimedOutError, "read timed out");
-                callback.setReturnValues(timeoutError);
-                callback.notifySuccess();
+                balFuture.complete(timeoutError);
                 cancel();
             }
         };

--- a/socket-native/src/main/java/org/ballerinalang/stdlib/socket/tcp/SelectorManager.java
+++ b/socket-native/src/main/java/org/ballerinalang/stdlib/socket/tcp/SelectorManager.java
@@ -338,8 +338,7 @@ public class SelectorManager {
             }
             byte[] bytes = SocketUtils
                     .getByteArrayFromByteBuffer(callback.getBuffer() == null ? buffer : callback.getBuffer());
-            callback.getCallback().setReturnValues(createUdpSocketReturnValue(callback, bytes, remoteAddress));
-            callback.getCallback().notifySuccess();
+            callback.getFuture().complete(createUdpSocketReturnValue(callback, bytes, remoteAddress));
             callback.cancelTimeout();
         } catch (CancelledKeyException | ClosedChannelException e) {
             processError(callback, null, "connection closed");
@@ -379,8 +378,7 @@ public class SelectorManager {
             }
             byte[] bytes = SocketUtils
                     .getByteArrayFromByteBuffer(callback.getBuffer() == null ? buffer : callback.getBuffer());
-            callback.getCallback().setReturnValues(createTcpSocketReturnValue(callback, bytes));
-            callback.getCallback().notifySuccess();
+            callback.getFuture().complete(createTcpSocketReturnValue(callback, bytes));
             callback.cancelTimeout();
         } catch (NotYetConnectedException e) {
             processError(callback, null, "connection not yet connected");
@@ -398,8 +396,7 @@ public class SelectorManager {
     private void processError(ReadPendingCallback callback, SocketConstants.ErrorType type, String msg) {
         BError socketError =
                 type == null ? SocketUtils.createSocketError(msg) : SocketUtils.createSocketError(type, msg);
-        callback.getCallback().setReturnValues(socketError);
-        callback.getCallback().notifySuccess();
+        callback.getFuture().complete(socketError);
     }
 
     private TupleValueImpl createTcpSocketReturnValue(ReadPendingCallback callback, byte[] bytes) {


### PR DESCRIPTION
## Purpose
Remove deprecated API

## Goals
Replace deprecated API NonBlockingCallback with BalEnv param for interop

## Related PRs
API deprecated in - ballerina-platform/ballerina-lang#25787
Duplicate change prior to stdlib move - ballerina-platform/ballerina-lang#25854
