### PR TITLE
Migrate Socket Connector to JDK 11

### DIFF
--- a/.github/workflows/build-master.yml
+++ b/.github/workflows/build-master.yml
@@ -15,10 +15,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Set up JDK 1.8
+      - name: Set up JDK 11
         uses: actions/setup-java@v1
         with:
-          java-version: 1.8
+          java-version: 11
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
       - name: Build with Gradle

--- a/.github/workflows/daily-build.yml
+++ b/.github/workflows/daily-build.yml
@@ -11,10 +11,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v1
-      - name: Set up JDK 1.8
+      - name: Set up JDK 11
         uses: actions/setup-java@v1
         with:
-          java-version: 1.8
+          java-version: 11
       - name: Build with Gradle
         env:
           packageUser: ${{ secrets.BALLERINA_BOT_USERNAME }}
@@ -27,10 +27,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v1
-      - name: Set up JDK 1.8
+      - name: Set up JDK 11
         uses: actions/setup-java@v1
         with:
-          java-version: 1.8
+          java-version: 11
       - name: Build with Gradle
         env:
           packageUser: ${{ secrets.BALLERINA_BOT_USERNAME }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -12,10 +12,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Set up JDK 1.8
+      - name: Set up JDK 11
         uses: actions/setup-java@v1
         with:
-          java-version: 1.8
+          java-version: 11
       - name: Set version env variable
         run: echo ::set-env name=VERSION::$((grep -w "version" | cut -d= -f2) < gradle.properties | cut -d- -f1)
       - name : Pre release depenency version update

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -9,10 +9,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v1
-      - name: Set up JDK 1.8
+      - name: Set up JDK 11
         uses: actions/setup-java@v1
         with:
-          java-version: 1.8
+          java-version: 11
       - name: Build with Gradle
         env:
           packageUser: ${{ secrets.BALLERINA_BOT_USERNAME }}
@@ -25,10 +25,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v1
-      - name: Set up JDK 1.8
+      - name: Set up JDK 11
         uses: actions/setup-java@v1
         with:
-          java-version: 1.8
+          java-version: 11
       - name: Build with Gradle
         env:
           packageUser: ${{ secrets.BALLERINA_BOT_USERNAME }}

--- a/README.md
+++ b/README.md
@@ -18,11 +18,11 @@ For example demonstrations of the usage, go to [Ballerina By Examples](https://b
 
 ### Setting Up the Prerequisites
 
-1. Download and install Java SE Development Kit (JDK) version 8 (from one of the following locations).
+1. Download and install Java SE Development Kit (JDK) version 11 (from one of the following locations).
 
-   * [Oracle](https://www.oracle.com/java/technologies/javase/javase-jdk8-downloads.html)
+   * [Oracle](https://www.oracle.com/java/technologies/javase-jdk11-downloads.html)
    
-   * [OpenJDK](http://openjdk.java.net/install/index.html)
+   * [OpenJDK](https://adoptopenjdk.net/)
    
         > **Note:** Set the JAVA_HOME environment variable to the path name of the directory into which you installed JDK.
      

--- a/socket-ballerina/Ballerina.toml
+++ b/socket-ballerina/Ballerina.toml
@@ -7,7 +7,7 @@ version = "@toml.version@"
 "ballerina/log" = "@stdlib.log.version@"
 
 [platform]
-target = "java8"
+target = "java11"
 
     [[platform.libraries]]
     artifactId = "socket"

--- a/socket-ballerina/build.gradle
+++ b/socket-ballerina/build.gradle
@@ -142,9 +142,9 @@ task ballerinaTest {
             environment "JAVA_OPTS", "-DBALLERINA_DEV_COMPILE_BALLERINA_ORG=true"
             environment "STDLIB_VERSION", tomlVersion
             if (Os.isFamily(Os.FAMILY_WINDOWS)) {
-                commandLine 'cmd', '/c', "$distributionBinPath/ballerina.bat test --code-coverage --all ${debugParams} && exit %%ERRORLEVEL%%"
+                commandLine 'cmd', '/c', "$distributionBinPath/ballerina.bat test --all ${debugParams} && exit %%ERRORLEVEL%%"
             } else {
-                commandLine 'sh', '-c', "$distributionBinPath/ballerina test --code-coverage --all ${debugParams}"
+                commandLine 'sh', '-c', "$distributionBinPath/ballerina test --all ${debugParams}"
             }
         }
     }

--- a/socket-native/build.gradle
+++ b/socket-native/build.gradle
@@ -17,12 +17,38 @@
 
 plugins {
     id 'java'
+    id 'checkstyle'
 }
 
 description = 'Ballerina - Socket Java Utils'
 
 dependencies {
+    checkstyle project(':build-config:checkstyle')
+    checkstyle "com.puppycrawl.tools:checkstyle:${puppycrawlCheckstyleVersion}"
+
     compile group: 'org.ballerinalang', name: 'ballerina-lang', version: "${ballerinaLangVersion}"
     compile group: 'org.ballerinalang', name: 'ballerina-runtime', version: "${ballerinaLangVersion}"
     compile group: 'org.slf4j', name: 'slf4j-jdk14', version: "${slf4jVersion}"
+}
+
+checkstyle {
+    toolVersion '7.8.2'
+    configFile rootProject.file("build-config/checkstyle/build/checkstyle.xml")
+    configProperties = ["suppressionFile" : file("${rootDir}/build-config/checkstyle/build/suppressions.xml")]
+}
+
+def excludePattern = '**/module-info.java'
+tasks.withType(Checkstyle) {
+    exclude excludePattern
+}
+
+checkstyleMain.dependsOn(":build-config:checkstyle:downloadMultipleFiles")
+
+compileJava {
+    doFirst {
+        options.compilerArgs = [
+                '--module-path', classpath.asPath,
+        ]
+        classpath = files()
+    }
 }

--- a/socket-native/src/main/java/module-info.java
+++ b/socket-native/src/main/java/module-info.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+module io.ballerina.stdlib.socket {
+    requires io.ballerina.jvm;
+    requires io.ballerina.lang;
+    requires org.slf4j;
+    exports org.ballerinalang.stdlib.socket.compiler;
+    exports org.ballerinalang.stdlib.socket.endpoint.tcp;
+    exports org.ballerinalang.stdlib.socket.endpoint.udp;
+    exports org.ballerinalang.stdlib.socket.tcp;
+}

--- a/socket-native/src/main/java/org/ballerinalang/stdlib/socket/endpoint/udp/ClientActions.java
+++ b/socket-native/src/main/java/org/ballerinalang/stdlib/socket/endpoint/udp/ClientActions.java
@@ -91,7 +91,8 @@ public class ClientActions {
             if (address != null) {
                 BMap<BString, Object> addressRecord = (BMap<BString, Object>) address;
                 String host = getHostFromAddress(addressRecord);
-                int port = addressRecord.getIntValue(BStringUtils.fromString(SocketConstants.CONFIG_FIELD_PORT)).intValue();
+                int port = addressRecord.getIntValue(BStringUtils.fromString(SocketConstants.CONFIG_FIELD_PORT))
+                        .intValue();
                 if (host == null) {
                     socketChannel.bind(new InetSocketAddress(port));
                 } else {

--- a/socket-test-utils/build.gradle
+++ b/socket-test-utils/build.gradle
@@ -28,3 +28,11 @@ dependencies {
     compile project(":socket-native")
 }
 
+compileJava {
+    doFirst {
+        options.compilerArgs = [
+                '--module-path', classpath.asPath,
+        ]
+        classpath = files()
+    }
+}

--- a/socket-test-utils/src/main/java/module-info.java
+++ b/socket-test-utils/src/main/java/module-info.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+module io.ballerina.stdlib.socket.testutils {
+    requires io.ballerina.jvm;
+    requires org.slf4j;
+    requires io.ballerina.stdlib.socket;
+    exports org.ballerinalang.stdlib.socket.testutils;
+}


### PR DESCRIPTION
## Purpose
Migrate Socket Connector to JDK 11 and add Checkstyle verification. Resolves https://github.com/ballerina-platform/module-ballerina-socket/issues/56
