### PR TITLE
Migrate Scheduler to BRuntime

### DIFF
--- a/socket-native/src/main/java/org/ballerinalang/stdlib/socket/endpoint/tcp/ClientActions.java
+++ b/socket-native/src/main/java/org/ballerinalang/stdlib/socket/endpoint/tcp/ClientActions.java
@@ -25,7 +25,6 @@ import org.ballerinalang.jvm.api.values.BError;
 import org.ballerinalang.jvm.api.values.BMap;
 import org.ballerinalang.jvm.api.values.BObject;
 import org.ballerinalang.jvm.api.values.BString;
-import org.ballerinalang.jvm.scheduling.Scheduler;
 import org.ballerinalang.jvm.values.ArrayValue;
 import org.ballerinalang.stdlib.socket.SocketConstants;
 import org.ballerinalang.stdlib.socket.exceptions.SelectorInitializeException;
@@ -59,7 +58,7 @@ import static java.nio.channels.SelectionKey.OP_READ;
 public class ClientActions {
     private static final Logger log = LoggerFactory.getLogger(ClientActions.class);
 
-    public static Object initEndpoint(BObject client, BMap<BString, Object> config) {
+    public static Object initEndpoint(BalEnv env, BObject client, BMap<BString, Object> config) {
         Object returnValue = null;
         try {
             SocketChannel socketChannel = SocketChannel.open();
@@ -73,7 +72,7 @@ public class ClientActions {
             client.addNativeData(SocketConstants.CLIENT_CONFIG, config);
             final long readTimeout = config.getIntValue(BStringUtils.fromString(SocketConstants.READ_TIMEOUT));
             client.addNativeData(SocketConstants.SOCKET_SERVICE,
-                    new SocketService(socketChannel, Scheduler.getStrand().scheduler, callbackService, readTimeout));
+                    new SocketService(socketChannel, env.getRuntime(), callbackService, readTimeout));
         } catch (SocketException e) {
             returnValue = SocketUtils.createSocketError("unable to bind the local socket port");
         } catch (IOException e) {

--- a/socket-native/src/main/java/org/ballerinalang/stdlib/socket/endpoint/tcp/ServerActions.java
+++ b/socket-native/src/main/java/org/ballerinalang/stdlib/socket/endpoint/tcp/ServerActions.java
@@ -18,13 +18,13 @@
 
 package org.ballerinalang.stdlib.socket.endpoint.tcp;
 
+import org.ballerinalang.jvm.api.BRuntime;
 import org.ballerinalang.jvm.api.BStringUtils;
 import org.ballerinalang.jvm.api.BalEnv;
 import org.ballerinalang.jvm.api.BalFuture;
 import org.ballerinalang.jvm.api.values.BMap;
 import org.ballerinalang.jvm.api.values.BObject;
 import org.ballerinalang.jvm.api.values.BString;
-import org.ballerinalang.jvm.scheduling.Scheduler;
 import org.ballerinalang.stdlib.socket.SocketConstants;
 import org.ballerinalang.stdlib.socket.exceptions.SelectorInitializeException;
 import org.ballerinalang.stdlib.socket.tcp.ChannelRegisterCallback;
@@ -74,18 +74,18 @@ public class ServerActions {
         return null;
     }
 
-    public static Object register(BObject listener, BObject service) {
+    public static Object register(BalEnv env, BObject listener, BObject service) {
         final SocketService socketService =
-                getSocketService(listener, Scheduler.getStrand().scheduler, service);
+                getSocketService(listener, env.getRuntime(), service);
         listener.addNativeData(SocketConstants.SOCKET_SERVICE, socketService);
         return null;
     }
 
-    private static SocketService getSocketService(BObject listener, Scheduler scheduler, BObject service) {
+    private static SocketService getSocketService(BObject listener, BRuntime runtime, BObject service) {
         ServerSocketChannel serverSocket =
                 (ServerSocketChannel) listener.getNativeData(SocketConstants.SERVER_SOCKET_KEY);
         long timeout = (long) listener.getNativeData(READ_TIMEOUT);
-        return new SocketService(serverSocket, scheduler, service, timeout);
+        return new SocketService(serverSocket, runtime, service, timeout);
     }
 
     public static Object start(BalEnv env, BObject listener) {

--- a/socket-native/src/main/java/org/ballerinalang/stdlib/socket/endpoint/udp/ClientActions.java
+++ b/socket-native/src/main/java/org/ballerinalang/stdlib/socket/endpoint/udp/ClientActions.java
@@ -23,7 +23,6 @@ import org.ballerinalang.jvm.api.BalFuture;
 import org.ballerinalang.jvm.api.values.BMap;
 import org.ballerinalang.jvm.api.values.BObject;
 import org.ballerinalang.jvm.api.values.BString;
-import org.ballerinalang.jvm.scheduling.Scheduler;
 import org.ballerinalang.jvm.values.ArrayValue;
 import org.ballerinalang.stdlib.socket.SocketConstants;
 import org.ballerinalang.stdlib.socket.exceptions.SelectorInitializeException;
@@ -100,7 +99,7 @@ public class ClientActions {
                 }
             }
             long timeout = config.getIntValue(BStringUtils.fromString(READ_TIMEOUT));
-            socketService = new SocketService(socketChannel, Scheduler.getStrand().scheduler, null, timeout);
+            socketService = new SocketService(socketChannel, env.getRuntime(), null, timeout);
             client.addNativeData(SOCKET_SERVICE, socketService);
             selectorManager = SelectorManager.getInstance();
             selectorManager.start();

--- a/socket-native/src/main/java/org/ballerinalang/stdlib/socket/tcp/SelectorDispatcher.java
+++ b/socket-native/src/main/java/org/ballerinalang/stdlib/socket/tcp/SelectorDispatcher.java
@@ -18,7 +18,6 @@
 
 package org.ballerinalang.stdlib.socket.tcp;
 
-import org.ballerinalang.jvm.api.BExecutor;
 import org.ballerinalang.jvm.api.values.BError;
 import org.ballerinalang.jvm.api.values.BObject;
 import org.ballerinalang.jvm.util.exceptions.BallerinaConnectorException;
@@ -47,7 +46,7 @@ public class SelectorDispatcher {
     static void invokeOnError(SocketService socketService, String errorMsg) {
         try {
             Object[] params = getOnErrorResourceSignature(socketService, errorMsg);
-            BExecutor.submit(socketService.getScheduler(), socketService.getService(), RESOURCE_ON_ERROR,
+            socketService.getRuntime().invokeMethodAsync(socketService.getService(), RESOURCE_ON_ERROR,
                     null, null, new TCPSocketCallback(socketService), null, params);
         } catch (Throwable e) {
             log.error("Error while executing onError resource", e);
@@ -65,7 +64,7 @@ public class SelectorDispatcher {
         try {
             final BObject caller = SocketUtils.createClient(socketService);
             Object[] params = new Object[] { caller, true, error, true };
-            BExecutor.submit(socketService.getScheduler(), socketService.getService(), RESOURCE_ON_ERROR,
+            socketService.getRuntime().invokeMethodAsync(socketService.getService(), RESOURCE_ON_ERROR,
                     null, null, callback, null,
                     params);
         } catch (Throwable e) {
@@ -81,7 +80,7 @@ public class SelectorDispatcher {
     static void invokeReadReady(SocketService socketService) {
         try {
             Object[] params = getReadReadyResourceSignature(socketService);
-            BExecutor.submit(socketService.getScheduler(), socketService.getService(), RESOURCE_ON_READ_READY,
+            socketService.getRuntime().invokeMethodAsync(socketService.getService(), RESOURCE_ON_READ_READY,
                     null, null, new TCPSocketReadCallback(socketService), null, params);
         } catch (BallerinaConnectorException e) {
             invokeOnError(socketService, e.getMessage());
@@ -97,7 +96,7 @@ public class SelectorDispatcher {
         try {
             final BObject clientObj = SocketUtils.createClient(socketService);
             Object[] params = new Object[] { clientObj, true };
-            BExecutor.submit(socketService.getScheduler(), socketService.getService(), RESOURCE_ON_CONNECT,
+            socketService.getRuntime().invokeMethodAsync(socketService.getService(), RESOURCE_ON_CONNECT,
                     null, null, new TCPSocketCallback(socketService), null, params);
         } catch (BallerinaConnectorException e) {
             invokeOnError(socketService, e.getMessage());

--- a/socket-native/src/main/java/org/ballerinalang/stdlib/socket/tcp/SelectorManager.java
+++ b/socket-native/src/main/java/org/ballerinalang/stdlib/socket/tcp/SelectorManager.java
@@ -240,7 +240,7 @@ public class SelectorManager {
             client.configureBlocking(false);
             // Creating a new SocketService instance with the newly accepted client.
             // We don't need the ServerSocketChannel in here since we have all the necessary resources.
-            SocketService clientSocketService = new SocketService(client, socketService.getScheduler(),
+            SocketService clientSocketService = new SocketService(client, socketService.getRuntime(),
                     socketService.getService(), socketService.getReadTimeout());
             // Registering the channel against the selector directly without going through the queue,
             // since we are in same thread.
@@ -248,20 +248,20 @@ public class SelectorManager {
             SelectorDispatcher.invokeOnConnect(clientSocketService);
         } catch (ClosedByInterruptException e) {
             SelectorDispatcher
-                    .invokeOnError(new SocketService(socketService.getScheduler(), socketService.getService()),
+                    .invokeOnError(new SocketService(socketService.getRuntime(), socketService.getService()),
                     "client accept interrupt by another process");
         } catch (AsynchronousCloseException e) {
             SelectorDispatcher
-                    .invokeOnError(new SocketService(socketService.getScheduler(), socketService.getService()),
+                    .invokeOnError(new SocketService(socketService.getRuntime(), socketService.getService()),
                             "client closed by another process");
         } catch (ClosedChannelException e) {
             SelectorDispatcher
-                    .invokeOnError(new SocketService(socketService.getScheduler(), socketService.getService()),
+                    .invokeOnError(new SocketService(socketService.getRuntime(), socketService.getService()),
                             "client is already closed");
         } catch (IOException e) {
             log.error("An error occurred while accepting new client", e);
             SelectorDispatcher
-                    .invokeOnError(new SocketService(socketService.getScheduler(), socketService.getService()),
+                    .invokeOnError(new SocketService(socketService.getRuntime(), socketService.getService()),
                             "unable to accept a new client. " +  e.getMessage());
         }
     }

--- a/socket-native/src/main/java/org/ballerinalang/stdlib/socket/tcp/SocketService.java
+++ b/socket-native/src/main/java/org/ballerinalang/stdlib/socket/tcp/SocketService.java
@@ -18,8 +18,8 @@
 
 package org.ballerinalang.stdlib.socket.tcp;
 
+import org.ballerinalang.jvm.api.BRuntime;
 import org.ballerinalang.jvm.api.values.BObject;
-import org.ballerinalang.jvm.scheduling.Scheduler;
 
 import java.nio.channels.SelectableChannel;
 import java.util.concurrent.Semaphore;
@@ -36,17 +36,17 @@ public class SocketService {
     private SelectableChannel socketChannel;
     private long readTimeout;
     private BObject service;
-    private Scheduler scheduler;
+    private BRuntime runtime;
 
-    public SocketService(SelectableChannel socketChannel, Scheduler scheduler, BObject service, long readTimeout) {
+    public SocketService(SelectableChannel socketChannel, BRuntime runtime, BObject service, long readTimeout) {
         this.socketChannel = socketChannel;
-        this.scheduler = scheduler;
+        this.runtime = runtime;
         this.service = service;
         this.readTimeout = readTimeout;
     }
 
-    public SocketService(Scheduler scheduler, BObject service) {
-        this.scheduler = scheduler;
+    public SocketService(BRuntime runtime, BObject service) {
+        this.runtime = runtime;
         this.service = service;
     }
 
@@ -54,8 +54,8 @@ public class SocketService {
         return socketChannel;
     }
 
-    public Scheduler getScheduler() {
-        return scheduler;
+    public BRuntime getRuntime() {
+        return runtime;
     }
 
     public BObject getService() {


### PR DESCRIPTION
## Purpose
Migrate `BExecutor` functionality to `invokeMethodAsync` of `BRuntime`. Resolves https://github.com/ballerina-platform/module-ballerina-socket/issues/59 .